### PR TITLE
test met xargs fails - solved

### DIFF
--- a/labo6/tests/04-datum.bats
+++ b/labo6/tests/04-datum.bats
@@ -43,7 +43,7 @@ teardown() {
 
 @test "Controleer uitvoer" {
   output=$(mktemp)
-  day=$(date)
+  day=$(date | sed -e 's/  / /g')
 
   # Schrijf uitvoer weg naar tijdelijk bestand
   bash "${script}" > "${output}"


### PR DESCRIPTION
Het commando "date" geeft soms twee spaties weer tussen opeenvolgende velden.
Het commando sed vervangt deze witruimte door telkens één spatie, zodat de laatste test ook altijd werkt.